### PR TITLE
Add script to retrieve and decode EC2 userData across all AWS regions

### DIFF
--- a/EC2userDataDumper.sh
+++ b/EC2userDataDumper.sh
@@ -54,7 +54,7 @@ regions=(
 for region in "${regions[@]}"; do
   echo ""
   echo "=============================="
-  echo "🔍 Region: $region"
+  echo "Region: $region"
   echo "=============================="
 
   instance_ids=$(aws ec2 describe-instances --region "$region" $PROFILE_OPT \
@@ -67,7 +67,7 @@ for region in "${regions[@]}"; do
 
   for instance_id in $instance_ids; do
     echo ""
-    echo "➡️  Getting userData for instance: $instance_id"
+    echo "Getting userData for instance: $instance_id"
 
     user_data=$(aws ec2 describe-instance-attribute --region "$region" $PROFILE_OPT \
       --instance-id "$instance_id" --attribute userData --output text 2>/dev/null)
@@ -78,12 +78,12 @@ for region in "${regions[@]}"; do
       echo "📦 Base64-encoded userData:"
       echo "$encoded"
       echo ""
-      echo "🔓 Decoded userData:"
+      echo "Decoded userData:"
       echo "------------------------------"
       echo "$encoded" | base64 -d 2>/dev/null || echo "[!] Failed to decode userData"
       echo "------------------------------"
     else
-      echo "⚠️  No userData found for instance $instance_id"
+      echo "No userData found for instance $instance_id"
     fi
   done
 done

--- a/EC2userDataDumper.sh
+++ b/EC2userDataDumper.sh
@@ -9,7 +9,7 @@ cat << "EOF"
  \____/_|\___/ \__,_|\__,_\____/|_|  \___|\__,_|\___|_| |_(_)_|\___/ 
 
 
-AWS Script that retrieves and base64 decodes userData from EC2 instances across all regions.
+AWS Script that retrieves and base64 decodes userData from EC2 instances across all regions with optional profile.
 
 EOF
 

--- a/EC2userDataDumper.sh
+++ b/EC2userDataDumper.sh
@@ -75,7 +75,7 @@ for region in "${regions[@]}"; do
     if [ -n "$user_data" ]; then
       encoded=$(echo "$user_data" | sed 's/^USERDATA\s*//' | sed '1d' | sed 's/^[[:space:]]*//')
 
-      echo "📦 Base64-encoded userData:"
+      echo "Base64-encoded userData:"
       echo "$encoded"
       echo ""
       echo "Decoded userData:"

--- a/EC2userDataDumper.sh
+++ b/EC2userDataDumper.sh
@@ -9,40 +9,82 @@ cat << "EOF"
  \____/_|\___/ \__,_|\__,_\____/|_|  \___|\__,_|\___|_| |_(_)_|\___/ 
 
 
-AWS Script that retrieves and base64 decodes userData from EC2 instances.
-
+AWS Script that retrieves and base64 decodes userData from EC2 instances across all regions.
 
 EOF
 
-# Get a list of instance IDs using describe-instances
-instance_ids=$(aws ec2 describe-instances --query 'Reservations[].Instances[].InstanceId' --output text)
-
-# Loop through each instance ID
-for instance_id in $instance_ids; do
-    
-    echo "Getting userData for instance: $instance_id"
-    
-    # Try to retrieve userData for the instance
-    user_data=$(aws ec2 describe-instance-attribute --instance-id "$instance_id" --attribute userData --output text 2>/dev/null)
-    
-    # Check if userData is available
-    if [ -n "$user_data" ]; then
-    
-        # Remove "USERDATA" and leading spaces
-        removedUserData=$(echo "$user_data" | sed 's/^USERDATA\s*//')
-        user_data=$(echo "$removedUserData" | sed '1d' | sed 's/^[[:space:]]*//')
-        echo "userData for instance $instance_id (base64 encoded):"
-        echo "$user_data"
-        
-        # Base64 decode the userData
-        decoded_user_data=$(echo "$user_data" | base64 -d)
-        echo "Decoded userData for instance $instance_id:"
-        echo "                                           "
-        echo "                                           "
-        echo "$decoded_user_data"
-        echo "                                           "
-        echo "                                           "
-    else
-        echo "userData not available for instance $instance_id"
-    fi
+AWS_PROFILE=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --profile)
+      AWS_PROFILE="$2"
+      shift 2
+      ;;
+    *)
+      echo "[ERROR] Unknown argument: $1"
+      echo "Usage: $0 [--profile <aws-profile-name>]"
+      exit 1
+      ;;
+  esac
 done
+
+if [[ -n "$AWS_PROFILE" ]]; then
+  PROFILE_OPT="--profile $AWS_PROFILE"
+  echo "[+] Using AWS profile: $AWS_PROFILE"
+else
+  PROFILE_OPT=""
+  echo "[+] Using default AWS credentials"
+fi
+
+regions=(
+  "us-east-1" "us-east-2" "us-west-1" "us-west-2"
+  "af-south-1" "ap-east-1" "ap-south-1" "ap-south-2"
+  "ap-southeast-1" "ap-southeast-2" "ap-southeast-3" "ap-southeast-4"
+  "ap-northeast-1" "ap-northeast-2" "ap-northeast-3"
+  "ca-central-1"
+  "eu-central-1" "eu-central-2"
+  "eu-west-1" "eu-west-2" "eu-west-3"
+  "eu-north-1"
+  "eu-south-1" "eu-south-2"
+  "il-central-1"
+  "me-south-1" "me-central-1"
+  "sa-east-1"
+)
+
+for region in "${regions[@]}"; do
+  echo ""
+  echo "=============================="
+  echo "🔍 Region: $region"
+  echo "=============================="
+
+  instance_ids=$(aws ec2 describe-instances --region "$region" $PROFILE_OPT \
+    --query 'Reservations[].Instances[].InstanceId' --output text 2>/dev/null)
+
+  if [[ -z "$instance_ids" ]]; then
+    echo "No instances found or access denied in region $region"
+    continue
+  fi
+
+  for instance_id in $instance_ids; do
+    echo ""
+    echo "➡️  Getting userData for instance: $instance_id"
+
+    user_data=$(aws ec2 describe-instance-attribute --region "$region" $PROFILE_OPT \
+      --instance-id "$instance_id" --attribute userData --output text 2>/dev/null)
+
+    if [ -n "$user_data" ]; then
+      encoded=$(echo "$user_data" | sed 's/^USERDATA\s*//' | sed '1d' | sed 's/^[[:space:]]*//')
+
+      echo "📦 Base64-encoded userData:"
+      echo "$encoded"
+      echo ""
+      echo "🔓 Decoded userData:"
+      echo "------------------------------"
+      echo "$encoded" | base64 -d 2>/dev/null || echo "[!] Failed to decode userData"
+      echo "------------------------------"
+    else
+      echo "⚠️  No userData found for instance $instance_id"
+    fi
+  done
+done
+


### PR DESCRIPTION
This script enumerates all EC2 instances across a hardcoded list of AWS regions, retrieves their userData (if available), and base64-decodes the content for inspection. It supports an optional --profile argument to specify the AWS CLI profile, falling back to the default credentials if none is provided.

Key features:
- Compatible with limited IAM permissions (no describe-regions required)
- Iterates through a comprehensive list of AWS regions
- Clean output for both encoded and decoded userData
- Graceful error handling for missing or malformed userData

Tested with multiple AWS profiles and regions.

Let me know if you'd like this integrated into a more modular format or if you'd prefer output redirection options for later log analysis.